### PR TITLE
fixes to ICPointRew

### DIFF
--- a/doc/cookbook/initialconditions.rst
+++ b/doc/cookbook/initialconditions.rst
@@ -87,7 +87,7 @@ Try it out with::
   from ddm import Model, Fittable
   from ddm.models import BoundConstant
   from ddm.plot import model_gui
-  model = Model(IC=ICPointRewRatio(x0=Fittable(minval=0, maxval=1)),
+  model = Model(IC=ICPointRewRatio(x0=Fittable(minval=-1, maxval=1)),
                 bound=BoundConstant(B=Fittable(minval=.1, maxval=2)),
                 dx=.01, dt=.01)
   model_gui(model, conditions={"highreward": [0, 1]})

--- a/doc/cookbook/initialconditions.rst
+++ b/doc/cookbook/initialconditions.rst
@@ -72,6 +72,26 @@ In practice, these are very similar, but the latter gives a smoother
 derivative, which may be useful for gradient-based fitting methods
 (which are not used by default).
 
+When fitting both the initial condition and the bound height, it can
+be preferable to express the initial condition as a proportion of the total
+distance between the bounds. This ensures that the initial condition will always
+stay within the bounds, preventing errors in fitting.
+
+.. literalinclude:: ../downloads/cookbook.py
+   :language: python
+   :start-after: # Start ICPointRewRatio
+   :end-before: # End ICPointRewRatio
+
+Try it out with:: 
+
+  from ddm import Model, Fittable
+  from ddm.models import BoundConstant
+  from ddm.plot import model_gui
+  model = Model(IC=ICPointRewRatio(x0=Fittable(minval=0, maxval=1)),
+                bound=BoundConstant(B=Fittable(minval=.1, maxval=2)),
+                dx=.01, dt=.01)
+  model_gui(model, conditions={"highreward": [0, 1]})
+
 .. _ic-biased-range:
 
 Biased Initial Condition Range

--- a/doc/downloads/cookbook.py
+++ b/doc/downloads/cookbook.py
@@ -15,15 +15,15 @@ class ICPointRew(InitialCondition):
     required_parameters = ["x0"]
     required_conditions = ["highreward"]
     def get_IC(self, x, dx, conditions):
-        x0 = self.x0
+        start = np.round(self.x0/dx)
         # Positive bias for high reward conditions, negative for low reward
         if not conditions['highreward']:
-            x0 = 1-x0
-        shift_i = int((len(x)-1)*x0)
+            start = -start
+        shift_i = int(start + (len(x)-1)/2)
         assert shift_i >= 0 and shift_i < len(x), "Invalid initial conditions"
         pdf = np.zeros(len(x))
-        pdf[shift_i] = 1. # Initial condition at x=self.x0*2*B.
-        return pdf    
+        pdf[shift_i] = 1. # Initial condition at x=self.x0.
+        return pdf
 # End ICPointRew
 
 # Start ICPointRewInterp
@@ -53,6 +53,25 @@ class ICPointRewInterp(InitialCondition):
         pdf[shift_out_i] = w_out # Initial condition at the outer grid next to x=self.x0.
         return pdf
 # End ICPointRewInterp
+
+# Start ICPointRewRatio
+import numpy as np
+from ddm import InitialCondition
+class ICPointRewRatio(InitialCondition):
+    name = "A reward-biased starting point expressed as a proportion of the distance between the bounds."
+    required_parameters = ["x0"]
+    required_conditions = ["highreward"]
+    def get_IC(self, x, dx, conditions):
+        x0 = self.x0
+        # Positive bias for high reward conditions, negative for low reward
+        if not conditions['highreward']:
+            x0 = 1-x0
+        shift_i = int((len(x)-1)*x0)
+        assert shift_i >= 0 and shift_i < len(x), "Invalid initial conditions"
+        pdf = np.zeros(len(x))
+        pdf[shift_i] = 1. # Initial condition at x=self.x0*2*B.
+        return pdf    
+# End ICPointRewRatio
 
 # Start ICPointRange
 import numpy as np

--- a/doc/downloads/cookbook.py
+++ b/doc/downloads/cookbook.py
@@ -15,15 +15,15 @@ class ICPointRew(InitialCondition):
     required_parameters = ["x0"]
     required_conditions = ["highreward"]
     def get_IC(self, x, dx, conditions):
-        start = np.round(self.x0/dx)
+        x0 = self.x0
         # Positive bias for high reward conditions, negative for low reward
         if not conditions['highreward']:
-            start = -start
-        shift_i = int(start + (len(x)-1)/2)
+            x0 = 1-x0
+        shift_i = int((len(x)-1)*x0)
         assert shift_i >= 0 and shift_i < len(x), "Invalid initial conditions"
         pdf = np.zeros(len(x))
-        pdf[shift_i] = 1. # Initial condition at x=self.x0.
-        return pdf
+        pdf[shift_i] = 1. # Initial condition at x=self.x0*2*B.
+        return pdf    
 # End ICPointRew
 
 # Start ICPointRewInterp

--- a/doc/downloads/cookbook.py
+++ b/doc/downloads/cookbook.py
@@ -62,14 +62,15 @@ class ICPointRewRatio(InitialCondition):
     required_parameters = ["x0"]
     required_conditions = ["highreward"]
     def get_IC(self, x, dx, conditions):
-        x0 = self.x0
-        # Positive bias for high reward conditions, negative for low reward
+        x0 = self.x0/2 + .5 #rescale to between 0 and 1
+        # Bias > .5 for high reward, bias < .5 for low reward. 
+        # On original scale, positive bias for high reward conditions, negative for low reward
         if not conditions['highreward']:
             x0 = 1-x0
         shift_i = int((len(x)-1)*x0)
         assert shift_i >= 0 and shift_i < len(x), "Invalid initial conditions"
         pdf = np.zeros(len(x))
-        pdf[shift_i] = 1. # Initial condition at x=self.x0*2*B.
+        pdf[shift_i] = 1. # Initial condition at x=x0*2*B.
         return pdf    
 # End ICPointRewRatio
 


### PR DESCRIPTION
Expressing the initial condition as a percentage of the distance between bounds is more stable and prevents errors during fitting due to invalid initial conditions. See e.g. https://doi.org/10.7554/eLife.36018.001

This same logic applies to ddm.models.ic.ICPoint and ddm.models.ic.ICRange, but I did not modify those classes as I haven't used/tested them.

Thanks for a great package!