### PR TITLE
Fix underflow issue

### DIFF
--- a/ddm/analytic.py
+++ b/ddm/analytic.py
@@ -50,7 +50,7 @@ def analytic_ddm_linbound(a1, b1, a2, b2, teval):
 
     # Probability Distribution of reaction time
     dist = np.exp(-(a1+b1*teval)**2./teval/2)/np.sqrt(2*np.pi)/teval**1.5*suminc
-    dist = dist*(dist>np.finfo(np.float64).tiny) # make sure non-negative/won' cause underflow error
+    dist = dist*(dist>np.finfo(np.float64).tiny) # make sure non-negative/won't cause underflow error
     return dist
 
 def analytic_ddm(drift, noise, b, teval, b_slope=0):

--- a/ddm/analytic.py
+++ b/ddm/analytic.py
@@ -50,7 +50,7 @@ def analytic_ddm_linbound(a1, b1, a2, b2, teval):
 
     # Probability Distribution of reaction time
     dist = np.exp(-(a1+b1*teval)**2./teval/2)/np.sqrt(2*np.pi)/teval**1.5*suminc
-    dist = dist*(dist>0) # make sure non-negative
+    dist = dist*(dist>np.finfo(np.float64).tiny) # make sure non-negative/won' cause underflow error
     return dist
 
 def analytic_ddm(drift, noise, b, teval, b_slope=0):


### PR DESCRIPTION
When using the analytic solver, fits sometimes crash with an underflow exception as follows:

```
Traceback (most recent call last):
  File "/home/ntardiff/data/miniconda2/envs/py36/lib/python3.6/site-packages/pyddm-0.4.0-py3.6.egg/ddm/models/loss.py", line 183, in loss
  File "/home/ntardiff/data/miniconda2/envs/py36/lib/python3.6/site-packages/paranoid/decorators.py", line 114, in _decorated
    return func(*args, **kwargs)
  File "/home/ntardiff/data/miniconda2/envs/py36/lib/python3.6/site-packages/pyddm-0.4.0-py3.6.egg/ddm/solution.py", line 121, in pdf_corr
FloatingPointError: underflow encountered in true_divide

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "./priorGDDM.py", line 110, in <module>
    main()
  File "./priorGDDM.py", line 100, in main
    'recombination':0.9})
  File "/data/jet/ntardiff/data/goldlab/FitGDDM/gddmwrapper/base.py", line 101, in run_model
    model_fit = fit_adjust_model(sample=sample, model=model,**kwargs)
  File "/home/ntardiff/data/miniconda2/envs/py36/lib/python3.6/site-packages/pyddm-0.4.0-py3.6.egg/ddm/functions.py", line 345, in fit_adjust_model
  File "/home/ntardiff/data/miniconda2/envs/py36/lib/python3.6/site-packages/scipy/optimize/_differentialevolution.py", line 306, in differential_evolution
    ret = solver.solve()
  File "/home/ntardiff/data/miniconda2/envs/py36/lib/python3.6/site-packages/scipy/optimize/_differentialevolution.py", line 818, in solve
    constraints=self.constraints)
  File "/home/ntardiff/data/miniconda2/envs/py36/lib/python3.6/site-packages/scipy/optimize/_minimize.py", line 610, in minimize
    callback=callback, **options)
  File "/home/ntardiff/data/miniconda2/envs/py36/lib/python3.6/site-packages/scipy/optimize/lbfgsb.py", line 345, in _minimize_lbfgsb
    f, g = func_and_grad(x)
  File "/home/ntardiff/data/miniconda2/envs/py36/lib/python3.6/site-packages/scipy/optimize/lbfgsb.py", line 290, in func_and_grad
    f = fun(x, *args)
  File "/home/ntardiff/data/miniconda2/envs/py36/lib/python3.6/site-packages/scipy/optimize/optimize.py", line 327, in function_wrapper
    return function(*(wrapper_args + args))
  File "/home/ntardiff/data/miniconda2/envs/py36/lib/python3.6/site-packages/scipy/optimize/_differentialevolution.py", line 1265, in __call__
    return self.f(x, *self.args)
  File "/home/ntardiff/data/miniconda2/envs/py36/lib/python3.6/site-packages/pyddm-0.4.0-py3.6.egg/ddm/functions.py", line 329, in _fit_model
  File "/home/ntardiff/data/miniconda2/envs/py36/lib/python3.6/site-packages/paranoid/decorators.py", line 114, in _decorated
    return func(*args, **kwargs)
  File "/home/ntardiff/data/miniconda2/envs/py36/lib/python3.6/site-packages/pyddm-0.4.0-py3.6.egg/ddm/models/loss.py", line 186, in loss
  File "/home/ntardiff/data/miniconda2/envs/py36/lib/python3.6/site-packages/paranoid/decorators.py", line 114, in _decorated
    return func(*args, **kwargs)
  File "/home/ntardiff/data/miniconda2/envs/py36/lib/python3.6/site-packages/pyddm-0.4.0-py3.6.egg/ddm/solution.py", line 121, in pdf_corr
FloatingPointError: underflow encountered in true_divide
```
This seems to happen if the pdf from the analytic solver comes to include any numbers less than the smallest positive floating point number, such that when solution.pdf_corr() (or pdf_err()) divides the pdf by dt, a number is produced that also falls in this "subnormal" range. This is a hard error to reproduce outside of fitting, but I was able to reproduce it with the following parameter values:

```
    T_dur=2.05
    dx=.005
    dt=.002
    drift=.01
    noise=1
    b=3
    b_slope=5
```

I think this means underflow already occurred in computing the analytic solution, and the only reason an exception is raised here is that in the loss function the pdf functions are called under ```with np.errstate(all='raise'):```. So an alternative fix would be to allow the underflow here, too...

I actually tried to see if I could reduce underflow in analytic_ddm_linbound() by taking logs and such, but it didn't seem to make much difference to the output, didn't solve this error, and resulted in a performance decrement--but fixing numerical issues is not my area of expertise. 

More generally, I seem to get a lot of renormalization warnings when using the analytic solver on basically the same model I was solving numerically, but with a switch from exponentially to linearly collapsing bounds, so I don't know if that means the analytic solver is just more numerically unstable generally? This persisted after reducing dt, so I think it's due to extreme parameter values. Also, the renormalization warnings are for > 1.01, but in trying to solve the above error I noticed that pdfs < 1 can happen for two reasons: 1) RTs longer than T_dur; 2) very fast RTs that are less than the resolution of dt. Of course, the former is rightly captured by pdf_undec. The latter seems like a potential issue, but given that it will likely only happen for extreme parameter values during fitting, which probably will give poor fits, maybe it's not a major concern?