### PR TITLE
Implemented arbitrary pointwise initial conditions in analytic solver

### DIFF
--- a/ddm/model.py
+++ b/ddm/model.py
@@ -15,7 +15,7 @@ from . import parameters as param
 from .analytic import analytic_ddm
 from .models.drift import DriftConstant, Drift
 from .models.noise import NoiseConstant, Noise
-from .models.ic import ICPointSourceCenter, InitialCondition
+from .models.ic import ICPointSourceCenter, ICPoint, InitialCondition
 from .models.bound import BoundConstant, BoundCollapsingLinear, Bound
 from .models.overlay import OverlayNone, Overlay
 from .models.paranoid_types import Conditions
@@ -435,10 +435,10 @@ class Model(object):
         if "t" in noisefuncsig.parameters or "x" in noisefuncsig.parameters:
             return False
         # Check to make sure bound is one that we can solve for
-        if mt["Bound"] not in [BoundConstant, BoundCollapsingLinear]:
+        if not issubclass(mt["Bound"],(BoundConstant, BoundCollapsingLinear)):
             return False
-        # Make sure initial condition is at the center
-        if mt["IC"] != ICPointSourceCenter:
+        # Make sure initial condition is a single point
+        if not issubclass(mt['IC'],(ICPointSourceCenter,ICPoint)):
             return False
         # Assuming none of these is the case, return True.
         return True
@@ -490,26 +490,36 @@ class Model(object):
 
         Analytic solutions are only possible in a select number of
         special cases; in particular, it works for simple DDM and for
-        linearly collapsing bounds.  (See Anderson (1960) for
-        implementation details.)  For most reasonably complex models,
-        the method will fail.  Check whether a solution is possible
-        with has_analytic_solution().
+        linearly collapsing bounds and arbitrary single-point initial 
+        conditions. (See Anderson (1960) for implementation details.)  
+        For most reasonably complex models, the method will fail.  
+        Check whether a solution is possible with has_analytic_solution().
 
         If successful, this returns a Solution object describing the
         joint PDF.  If unsuccessful, this will raise an exception.
         """
         assert self.has_analytical_solution(), "Cannot solve for this model analytically"
         self.check_conditions_satisfied(conditions)
+        
+        #calculate shift in initial conditions if present
+        if isinstance(self.get_dependence('IC'),ICPoint):
+            ic = self.IC(conditions=conditions)
+            assert np.count_nonzero(ic)==1, "Cannot solve analytically for models with non-point initial conditions"
+            shift = np.flatnonzero(ic) / (len(ic) - 1) #rescale to proprotion of total bound height
+        else:
+            shift = None
+        
         # The analytic_ddm function does the heavy lifting.
         if isinstance(self.get_dependence('bound'), BoundConstant): # Simple DDM
             anal_pdf_corr, anal_pdf_err = analytic_ddm(self.get_dependence("drift").get_drift(t=0, conditions=conditions),
                                                        self.get_dependence("noise").get_noise(t=0, conditions=conditions),
-                                                       self.get_dependence("bound").get_bound(t=0, conditions=conditions), self.t_domain())
+                                                       self.get_dependence("bound").get_bound(t=0, conditions=conditions), 
+                                                       self.t_domain(), shift)
         elif isinstance(self.get_dependence('bound'), BoundCollapsingLinear): # Linearly Collapsing Bound
             anal_pdf_corr, anal_pdf_err = analytic_ddm(self.get_dependence("drift").get_drift(t=0, conditions=conditions),
                                                        self.get_dependence("noise").get_noise(t=0, conditions=conditions),
                                                        self.get_dependence("bound").get_bound(t=0, conditions=conditions),
-                                                       self.t_domain(), -self.get_dependence("bound").t) # TODO why must this be negative? -MS
+                                                       self.t_domain(), shift, -self.get_dependence("bound").t) # TODO why must this be negative? -MS
 
         ## Remove some abnormalities such as NaN due to trivial reasons.
         anal_pdf_corr[anal_pdf_corr==np.NaN] = 0. # FIXME Is this a bug? You can't use == to compare nan to nan...
@@ -528,7 +538,7 @@ class Model(object):
             anal_pdf_err /= pdfsum
 
         return self.get_dependence('overlay').apply(Solution(anal_pdf_corr*self.dt, anal_pdf_err*self.dt, self, conditions=conditions))
-
+    
     @accepts(Self, method=Set(["explicit", "implicit", "cn"]), conditions=Conditions, return_evolution=Boolean)
     @returns(Solution)
     @requires("method == 'explicit' --> self.can_solve_explicit(conditions=conditions)")

--- a/integration_tests.py
+++ b/integration_tests.py
@@ -135,6 +135,22 @@ class TestSimulation(TestCase):
         # maximum.
         # 
         # _modeltest_pdf_evolution(self.bound)
+    def test_ICPoint(self):
+        """Arbitrary pointwise initial condition"""
+        m = ddm.Model(name='ICPoint_test',
+              drift=ddm.DriftConstant(drift=2),
+              noise=ddm.NoiseConstant(noise=1.5),
+              bound=ddm.BoundConstant(B=1),
+              IC=ddm.ICPoint(x0=-.25))
+        _modeltest_numerical_vs_analytical(m, method="implicit", max_diff=.3, mean_diff=.2, prob_diff=.05)
+    def test_ICPoint_collapsing_bounds(self):
+        m = ddm.Model(name='ICPoint_BCollapsingLin_test',
+              drift=ddm.DriftConstant(drift=2),
+              noise=ddm.NoiseConstant(noise=1.5),
+              bound=ddm.BoundCollapsingLinear(B=1,t=0.5),
+              IC=ddm.ICPoint(x0=-.25))
+        _modeltest_numerical_vs_analytical(m, method="implicit", max_diff=.3, mean_diff=.2, prob_diff=.05)
+
 
 class TestFit(TestCase):
     def setUp(self):


### PR DESCRIPTION
Hi Max,

Congrats on the PyDDM paper getting published!

This pull request implements the ability to use the analytic solver for models with arbitrary pointwise initial conditions.

A couple of notes:
- In order to allow more flexibility for using the analytic solver with custom code, I changed models.has_analytical_solution() to return true as long as the Bound and IC model components are subclasses of acceptable built-in PyDDM classes. This puts some onus on the user to not do anything ridiculous, but greatly increases the number of cases in which you could try using the analytic solver.
- The analytic solution really breaks down when the initial conditions get too close to one of the bounds, and you end up w/ a lot of undecided probability mass. The numerical solver seems more robust in this regard, but in practice I'm not sure this is much of an issue since if you had initial conditions that close to the bound you'd have to wonder whether there was any evidence accumulation happening in your subject data at all. I don't understand the analytical algorithm well enough to know whether anything could be done to mitigate this issue.
- I've attached code that if run show very similar solutions when solving the same model (start shift and linear collapsing bounds) with the analytic and numerical solvers: [analytic_start_shift_example.txt](https://github.com/mwshinn/PyDDM/files/5086630/analytic_start_shift_example.txt)
- As a further check I also refit a model on example subject data that  I'd initially fit using the numerical solver and recovered very similar parameter values.
