### PR TITLE
Add seeded mutation for `hillclimb` fitting_method.

### DIFF
--- a/DDM_quick_tests.py
+++ b/DDM_quick_tests.py
@@ -25,7 +25,7 @@ from ddm.models.drift import DriftConstant, Drift
 from ddm.models.noise import NoiseConstant, Noise
 from ddm.models.bound import BoundConstant
 from ddm.models.overlay import OverlayChain, OverlayPoissonMixture, OverlayUniformMixture
-from ddm.functions import fit_model
+from ddm.functions import fit_model, fit_adjust_model
 
 SHOW_PLOTS = False
 
@@ -111,6 +111,25 @@ def test_fit_simple_ddm():
         plt.show()
 
     _verify_param_match("drift", "drift", m, mfit)
+    
+    # Verify seed functionality works as expected for `hillclimb` method
+    m = Model(name="DDM_seeded_hillclimb", dt=.01,
+              drift=DriftConstant(drift=2),
+              noise=NoiseConstant(noise=1),
+              bound=BoundConstant(B=1))
+    s = m.solve()
+    sample = s.resample(10000)
+    mfit = fit_adjust_model(sample, drift=DriftConstant(drift=Fittable(minval=0, maxval=10)),
+                            fitting_method='hillclimb', fitparams={seed=1})
+                            
+    m = Model(name="DDM_non_seeded_hillclimb", dt=.01,
+              drift=DriftConstant(drift=2),
+              noise=NoiseConstant(noise=1),
+              bound=BoundConstant(B=1))
+    s = m.solve()
+    sample = s.resample(10000)
+    mfit = fit_adjust_model(sample, drift=DriftConstant(drift=Fittable(minval=0, maxval=10)),
+                            fitting_method='hillclimb', fitparams={seed=None})
 
 # def test_fit_constant_drift_constant_noise():
 #     m = Model(name="DDM",

--- a/DDM_quick_tests.py
+++ b/DDM_quick_tests.py
@@ -25,7 +25,7 @@ from ddm.models.drift import DriftConstant, Drift
 from ddm.models.noise import NoiseConstant, Noise
 from ddm.models.bound import BoundConstant
 from ddm.models.overlay import OverlayChain, OverlayPoissonMixture, OverlayUniformMixture
-from ddm.functions import fit_model, fit_adjust_model
+from ddm.functions import fit_model
 
 SHOW_PLOTS = False
 
@@ -112,24 +112,25 @@ def test_fit_simple_ddm():
 
     _verify_param_match("drift", "drift", m, mfit)
     
+def test_fit_hillclimb_seed():
     # Verify seed functionality works as expected for `hillclimb` method
-    m = Model(name="DDM_seeded_hillclimb", dt=.01,
+    m = Model(name="DDM", dt=.01,
               drift=DriftConstant(drift=2),
               noise=NoiseConstant(noise=1),
               bound=BoundConstant(B=1))
     s = m.solve()
     sample = s.resample(10000)
-    mfit = fit_adjust_model(sample, drift=DriftConstant(drift=Fittable(minval=0, maxval=10)),
-                            fitting_method='hillclimb', fitparams={seed=1})
+    mfit = fit_model(sample, drift=DriftConstant(drift=Fittable(minval=0, maxval=10)),
+                    fitting_method='hillclimb', fitparams={'seed':1})
                             
-    m = Model(name="DDM_non_seeded_hillclimb", dt=.01,
+    m = Model(name="DDM", dt=.01,
               drift=DriftConstant(drift=2),
               noise=NoiseConstant(noise=1),
               bound=BoundConstant(B=1))
     s = m.solve()
     sample = s.resample(10000)
-    mfit = fit_adjust_model(sample, drift=DriftConstant(drift=Fittable(minval=0, maxval=10)),
-                            fitting_method='hillclimb', fitparams={seed=None})
+    mfit = fit_model(sample, drift=DriftConstant(drift=Fittable(minval=0, maxval=10)),
+                    fitting_method='hillclimb', fitparams={'seed':None})
 
 # def test_fit_constant_drift_constant_noise():
 #     m = Model(name="DDM",

--- a/ddm/functions.py
+++ b/ddm/functions.py
@@ -409,7 +409,7 @@ def evolution_strategy(fitness, x_0, mu=1, lmbda=3, copyparents=True, mutate_var
     if seed is None:
         mutate = lambda x : [e+np.random.normal(0, mutate_var) if np.random.random()<mutate_prob else e for e in x]
     else:
-        assert isinstance(seed, (int, np.int32, np.int64)), f'Expected seed to be <int>, got <{}>'.format(type(seed))
+        assert isinstance(seed, (int, np.int32, np.int64)), "Expected seed to be <int>, got <{}>".format(type(seed))
         rng = np.random.RandomState(seed)
         mutate = lambda x : [e+rng.normal(0, mutate_var) if rng.random()<mutate_prob else e for e in x]
     

--- a/ddm/functions.py
+++ b/ddm/functions.py
@@ -409,7 +409,7 @@ def evolution_strategy(fitness, x_0, mu=1, lmbda=3, copyparents=True, mutate_var
     if seed is None:
         mutate = lambda x : [e+np.random.normal(0, mutate_var) if np.random.random()<mutate_prob else e for e in x]
     else:
-        assert isinstance(seed, (int, np.int32, np.int64)), f'Expected seed to be <int>, got <{type(seed)}>'
+        assert isinstance(seed, (int, np.int32, np.int64)), f'Expected seed to be <int>, got <{}>'.format(type(seed))
         rng = np.random.RandomState(seed)
         mutate = lambda x : [e+rng.normal(0, mutate_var) if rng.random()<mutate_prob else e for e in x]
     

--- a/ddm/functions.py
+++ b/ddm/functions.py
@@ -433,7 +433,7 @@ def evolution_strategy(fitness, x_0, mu=1, lmbda=3, copyparents=True, mutate_var
         # Create the next generation population
         for q in Q:
             for _ in range(0, lmbda//mu):
-                new = mutate(x_0)
+                new = mutate(q[0])
                 fit = fitness(new)
                 if fit < best[1]:
                     best = (new, fit)

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -673,6 +673,18 @@ class TestMisc(TestCase):
         assert all(id(a) == id(b) for a,b in zip(m.get_model_parameters(), [p1, p2]))
         m.set_model_parameters([.5, .5])
         assert all(a == b for a,b in zip(m.get_model_parameters(), [.5, .5]))
+    def test_mutate_seeded()
+        """Assert deterministic solution if ddm.functions.mutate_seeded() is given seed"""
+        assert [1, 2.0009934283060224, 2.9997367755960487, 3.9986753891871323] \
+            == ddm.functions.mutate_seeded(np.arange(1,5), seed=42, i=1, mutate_var=.002, mutate_prob=.5)
+        assert [1, 1.999736775596049, 3, 3.9999770030201023] \
+            == ddm.functions.mutate_seeded(np.arange(1,5), seed=42, i=2, mutate_var=.002, mutate_prob=.5)
+        assert [1, 2.0032486907273266, 2.999166484305189, 4] \
+            == ddm.functions.mutate_seeded(np.arange(1,5), seed=0, i=1, mutate_var=.002, mutate_prob=.5)
+        assert [1, 1.999166484305189, 3, 4] \
+            == ddm.functions.mutate_seeded(np.arange(1,5), seed=0, i=2, mutate_var=.002, mutate_prob=.5)
+            
+            
         
 
         

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -673,7 +673,7 @@ class TestMisc(TestCase):
         assert all(id(a) == id(b) for a,b in zip(m.get_model_parameters(), [p1, p2]))
         m.set_model_parameters([.5, .5])
         assert all(a == b for a,b in zip(m.get_model_parameters(), [.5, .5]))
-    def test_mutate_seeded()
+    def test_mutate_seeded(self):
         """Assert deterministic solution if ddm.functions.mutate_seeded() is given seed"""
         assert [1, 2.0009934283060224, 2.9997367755960487, 3.9986753891871323] \
             == ddm.functions.mutate_seeded(np.arange(1,5), seed=42, i=1, mutate_var=.002, mutate_prob=.5)

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -673,16 +673,6 @@ class TestMisc(TestCase):
         assert all(id(a) == id(b) for a,b in zip(m.get_model_parameters(), [p1, p2]))
         m.set_model_parameters([.5, .5])
         assert all(a == b for a,b in zip(m.get_model_parameters(), [.5, .5]))
-    def test_mutate_seeded(self):
-        """Assert deterministic solution if ddm.functions.mutate_seeded() is given seed"""
-        assert [1, 2.0009934283060224, 2.9997367755960487, 3.9986753891871323] \
-            == ddm.functions.mutate_seeded(np.arange(1,5), seed=42, i=1, mutate_var=.002, mutate_prob=.5)
-        assert [1, 1.999736775596049, 3, 3.9999770030201023] \
-            == ddm.functions.mutate_seeded(np.arange(1,5), seed=42, i=2, mutate_var=.002, mutate_prob=.5)
-        assert [1, 2.0032486907273266, 2.999166484305189, 4] \
-            == ddm.functions.mutate_seeded(np.arange(1,5), seed=0, i=1, mutate_var=.002, mutate_prob=.5)
-        assert [1, 1.999166484305189, 3, 4] \
-            == ddm.functions.mutate_seeded(np.arange(1,5), seed=0, i=2, mutate_var=.002, mutate_prob=.5)
             
             
         


### PR DESCRIPTION
@mwshinn this is in reference to #61.

The fitting method `hillclimb` can now accept seeded values. This is turned off by default so that existing functionality remains the same and to adhere to the scipy standard. 

To include a seed, add a seed value <int> to fitparams using fit_model().

Example:
```
from ddm.models import  Model, Fittable
from ddm.models.drift import DriftConstant
from ddm.models.noise import NoiseConstant
from ddm.models.bound import BoundConstant
from ddm.functions import fit_model

m = Model(name="DDM", dt=.01,
              drift=DriftConstant(drift=2),
              noise=NoiseConstant(noise=1),
              bound=BoundConstant(B=1))
s = m.solve()
sample = s.resample(10000)
mfit = fit_model(sample, drift=DriftConstant(drift=Fittable(minval=0, maxval=10)),
                    fitting_method='hillclimb', fitparams={'seed':42})
```

Tests added to unit_test.py and DDM_quick_tests.py. All tests passing.

