### PR TITLE
Perform logging through Python's `logging` module

### DIFF
--- a/pyddm/__init__.py
+++ b/pyddm/__init__.py
@@ -19,6 +19,7 @@ from .functions import *
 
 from ._version import __version__
 
+functions._init_logger()
 
 # Some default functions for paranoid scientist
 import paranoid

--- a/pyddm/__init__.py
+++ b/pyddm/__init__.py
@@ -16,11 +16,9 @@ from .model import Model, Fittable, Fitted, FitResult
 from .sample import Sample
 from .solution import Solution
 from .functions import *
+from .logger import set_log_level
 
 from ._version import __version__
-
-from .logger import _init_logger, set_log_level
-_init_logger()
 
 # Some default functions for paranoid scientist
 import paranoid

--- a/pyddm/__init__.py
+++ b/pyddm/__init__.py
@@ -19,7 +19,8 @@ from .functions import *
 
 from ._version import __version__
 
-functions._init_logger()
+from .logger import _init_logger, set_log_level
+_init_logger()
 
 # Some default functions for paranoid scientist
 import paranoid

--- a/pyddm/functions.py
+++ b/pyddm/functions.py
@@ -52,9 +52,17 @@ def set_N_cpus(N):
 
 _logger = logging.getLogger(__package__)
 def _init_logger():
+    # Rewrite the textual representation of logging levels to make them a bit less scary
+    logging.addLevelName(logging.DEBUG, 'Debug')
+    logging.addLevelName(logging.INFO, 'Info')
+    logging.addLevelName(logging.WARNING, 'Warning')
+    logging.addLevelName(logging.ERROR, 'Error')
+    logging.addLevelName(logging.CRITICAL, 'Critical')
+    # Define custom formatting
     console_handler = logging.StreamHandler()
     console_handler.setFormatter(logging.Formatter('%(filename)s:%(lineno)d %(levelname)s: %(message)s'))
     _logger.addHandler(console_handler)
+    # By default, only show statements for "Debug" and up.
     set_debug_flag(False)
 
 @accepts(Boolean)

--- a/pyddm/functions.py
+++ b/pyddm/functions.py
@@ -10,7 +10,7 @@ __all__ = ['models_close', 'fit_model', 'fit_adjust_model',
            'get_model_loss', 'set_N_cpus']
 
 import copy
-
+import logging
 import numpy as np
 from scipy.optimize import minimize, basinhopping, differential_evolution, OptimizeResult
 
@@ -337,17 +337,17 @@ def fit_adjust_model(sample, model, fitparams=None, fitting_method="differential
             # they will give 1.000000000001.  This fixes that problem
             # to make sure the model is within its domain.
             if x > p.maxval:
-                if verbose:
-                    print("Warning: optimizer went out of bounds.  Setting %f to %f" % (x, p.maxval))
+                if verbose:  # TODO: do we still want this parameter given logging support?
+                    logging.warning("Optimizer went out of bounds.  Setting %f to %f" % (x, p.maxval))
                 x = p.maxval
             if x < p.minval:
                 if verbose:
-                    print("Warning: optimizer went out of bounds.  Setting %f to %f" % (x, p.minval))
+                    logging.warning("Optimizer went out of bounds.  Setting %f to %f" % (x, p.minval))
                 x = p.minval
             s(m, x)
         lossf = lf.loss(m)
         if verbose:
-            print(repr(m), "loss="+ str(lossf))
+            logging.info(repr(m) + " loss="+ str(lossf))
         return lossf
     # Cast to a dictionary if necessary
     if fitparams is None:
@@ -375,7 +375,7 @@ def fit_adjust_model(sample, model, fitparams=None, fitting_method="differential
                     nparams=len(params), samplesize=len(sample),
                     mess=(x_fit.message if "message" in x_fit.__dict__ else ""))
     m.fitresult = res
-    print("Params", x_fit.x, "gave", x_fit.fun)
+    logging.info("Params " + str(x_fit.x) + " gave " + str(x_fit.fun))
     for x,s in zip(x_fit.x, setters):
         s(m, x)
     if not verify:
@@ -635,10 +635,10 @@ def hit_boundary(model):
             pv = getattr(component, param_name) # Parameter value in the object
             if isinstance(pv, Fitted):
                 if (pv - pv.minval)/(pv.maxval-pv.minval) < .01: # No abs because pv always > pv.minval
-                    print("%s hit the lower boundary of %f with value %f" % (param_name, pv.minval, pv))
+                    logging.info("%s hit the lower boundary of %f with value %f" % (param_name, pv.minval, pv))  # TODO possibly make warning
                     hit = True
                 if (pv.maxval-pv)/(pv.maxval-pv.minval) < .01: # No abs because pv.maxval always > pv
-                    print("%s hit the lower boundary of %f with value %f" % (param_name, pv.maxval, pv))
+                    logging.info("%s hit the lower boundary of %f with value %f" % (param_name, pv.maxval, pv))  # TODO possibly make warning
                     hit = True
     return hit
 
@@ -719,4 +719,4 @@ def display_model(model, print_output=True):
     if not print_output:
         return OUT
     else:
-        print(OUT)
+        logging.info(OUT)  # TODO should this be print() or info?

--- a/pyddm/functions.py
+++ b/pyddm/functions.py
@@ -738,4 +738,4 @@ def display_model(model, print_output=True):
     if not print_output:
         return OUT
     else:
-        _logger.info(OUT)  # TODO should this be print() or info?
+        print(OUT)  # TODO I suspect this should remain print(), not be moved to logging?

--- a/pyddm/functions.py
+++ b/pyddm/functions.py
@@ -7,7 +7,7 @@
 __all__ = ['models_close', 'fit_model', 'fit_adjust_model',
            'evolution_strategy', 'solve_partial_conditions',
            'hit_boundary', 'dependence_hit_boundary', 'display_model',
-           'get_model_loss', 'set_N_cpus']
+           'get_model_loss', 'set_N_cpus', 'set_debug_flag']
 
 import copy
 import logging
@@ -50,6 +50,17 @@ def set_N_cpus(N):
     else:
         _parallel_pool = None
 
+_logger = logging.getLogger(__package__)
+def _init_logger():
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(logging.Formatter('%(filename)s:%(lineno)d %(levelname)s: %(message)s'))
+    _logger.addHandler(console_handler)
+    set_debug_flag(False)
+
+@accepts(Boolean)
+def set_debug_flag(debug):
+    level = logging.DEBUG if debug else logging.INFO
+    _logger.setLevel(level)
 
 @accepts(Model, Model, tol=Number)
 @requires("m1.get_model_type() == m2.get_model_type()")
@@ -338,16 +349,16 @@ def fit_adjust_model(sample, model, fitparams=None, fitting_method="differential
             # to make sure the model is within its domain.
             if x > p.maxval:
                 if verbose:  # TODO: do we still want this parameter given logging support?
-                    logging.warning("Optimizer went out of bounds.  Setting %f to %f" % (x, p.maxval))
+                    _logger.warning("Optimizer went out of bounds.  Setting %f to %f" % (x, p.maxval))
                 x = p.maxval
             if x < p.minval:
                 if verbose:
-                    logging.warning("Optimizer went out of bounds.  Setting %f to %f" % (x, p.minval))
+                    _logger.warning("Optimizer went out of bounds.  Setting %f to %f" % (x, p.minval))
                 x = p.minval
             s(m, x)
         lossf = lf.loss(m)
         if verbose:
-            logging.info(repr(m) + " loss="+ str(lossf))
+            _logger.info(repr(m) + " loss="+ str(lossf))
         return lossf
     # Cast to a dictionary if necessary
     if fitparams is None:
@@ -375,7 +386,7 @@ def fit_adjust_model(sample, model, fitparams=None, fitting_method="differential
                     nparams=len(params), samplesize=len(sample),
                     mess=(x_fit.message if "message" in x_fit.__dict__ else ""))
     m.fitresult = res
-    logging.info("Params " + str(x_fit.x) + " gave " + str(x_fit.fun))
+    _logger.info("Params " + str(x_fit.x) + " gave " + str(x_fit.fun))
     for x,s in zip(x_fit.x, setters):
         s(m, x)
     if not verify:
@@ -635,10 +646,10 @@ def hit_boundary(model):
             pv = getattr(component, param_name) # Parameter value in the object
             if isinstance(pv, Fitted):
                 if (pv - pv.minval)/(pv.maxval-pv.minval) < .01: # No abs because pv always > pv.minval
-                    logging.info("%s hit the lower boundary of %f with value %f" % (param_name, pv.minval, pv))  # TODO possibly make warning
+                    _logger.info("%s hit the lower boundary of %f with value %f" % (param_name, pv.minval, pv))  # TODO possibly make warning
                     hit = True
                 if (pv.maxval-pv)/(pv.maxval-pv.minval) < .01: # No abs because pv.maxval always > pv
-                    logging.info("%s hit the lower boundary of %f with value %f" % (param_name, pv.maxval, pv))  # TODO possibly make warning
+                    _logger.info("%s hit the lower boundary of %f with value %f" % (param_name, pv.maxval, pv))  # TODO possibly make warning
                     hit = True
     return hit
 
@@ -719,4 +730,4 @@ def display_model(model, print_output=True):
     if not print_output:
         return OUT
     else:
-        logging.info(OUT)  # TODO should this be print() or info?
+        _logger.info(OUT)  # TODO should this be print() or info?

--- a/pyddm/functions.py
+++ b/pyddm/functions.py
@@ -719,4 +719,4 @@ def display_model(model, print_output=True):
     if not print_output:
         return OUT
     else:
-        print(OUT)  # TODO I suspect this should remain print(), not be moved to logging?
+        print(OUT)

--- a/pyddm/logger.py
+++ b/pyddm/logger.py
@@ -1,0 +1,38 @@
+import logging
+
+DEFAULT_LOG_LEVEL = logging.INFO
+
+_logger_initialized = False
+logger = logging.getLogger(__package__)
+
+def _init_logger():
+    """Initialize the pyddm logger object.
+    
+    The logger is already ready to call and use, but this ensures that
+    messages are formatted as desired and output to console.
+    """
+    global _logger_initialized
+    if not _logger_initialized:
+        # Rewrite the textual representation of logging levels to make them a bit less scary
+        logging.addLevelName(logging.DEBUG, 'Debug')
+        logging.addLevelName(logging.INFO, 'Info')
+        logging.addLevelName(logging.WARNING, 'Warning')
+        logging.addLevelName(logging.ERROR, 'Error')
+        logging.addLevelName(logging.CRITICAL, 'Critical')
+        # Define custom formatting: produces messages that look like "Loglevel: <message here...>"
+        console_handler = logging.StreamHandler()
+        console_handler.setFormatter(logging.Formatter('%(levelname)s: %(message)s'))
+        logger.addHandler(console_handler)
+        # Set default log-level
+        _logger_initialized = True
+        set_log_level(DEFAULT_LOG_LEVEL)
+
+def set_log_level(level):
+    """Sets the log level throughout pyddm.
+    
+    `level` must be an int or str as allowed by the Python logging
+    module. See https://docs.python.org/3/library/logging.html for more.
+    """
+    if not _logger_initialized:
+        _init_logger()
+    logger.setLevel(level)

--- a/pyddm/logger.py
+++ b/pyddm/logger.py
@@ -2,30 +2,18 @@ import logging
 
 DEFAULT_LOG_LEVEL = logging.INFO
 
-_logger_initialized = False
 logger = logging.getLogger(__package__)
 
-def _init_logger():
-    """Initialize the pyddm logger object.
-    
-    The logger is already ready to call and use, but this ensures that
-    messages are formatted as desired and output to console.
-    """
-    global _logger_initialized
-    if not _logger_initialized:
-        # Rewrite the textual representation of logging levels to make them a bit less scary
-        logging.addLevelName(logging.DEBUG, 'Debug')
-        logging.addLevelName(logging.INFO, 'Info')
-        logging.addLevelName(logging.WARNING, 'Warning')
-        logging.addLevelName(logging.ERROR, 'Error')
-        logging.addLevelName(logging.CRITICAL, 'Critical')
-        # Define custom formatting: produces messages that look like "Loglevel: <message here...>"
-        console_handler = logging.StreamHandler()
-        console_handler.setFormatter(logging.Formatter('%(levelname)s: %(message)s'))
-        logger.addHandler(console_handler)
-        # Set default log-level
-        _logger_initialized = True
-        set_log_level(DEFAULT_LOG_LEVEL)
+# Rewrite the textual representation of logging levels to make them a bit less scary
+logging.addLevelName(logging.DEBUG, 'Debug')
+logging.addLevelName(logging.INFO, 'Info')
+logging.addLevelName(logging.WARNING, 'Warning')
+logging.addLevelName(logging.ERROR, 'Error')
+logging.addLevelName(logging.CRITICAL, 'Critical')
+# Define custom formatting: produces messages that look like "Loglevel: <message here...>"
+console_handler = logging.StreamHandler()
+console_handler.setFormatter(logging.Formatter('%(levelname)s: %(message)s'))
+logger.addHandler(console_handler)
 
 def set_log_level(level):
     """Sets the log level throughout pyddm.
@@ -33,6 +21,7 @@ def set_log_level(level):
     `level` must be an int or str as allowed by the Python logging
     module. See https://docs.python.org/3/library/logging.html for more.
     """
-    if not _logger_initialized:
-        _init_logger()
     logger.setLevel(level)
+
+# Set default log-level
+set_log_level(DEFAULT_LOG_LEVEL)

--- a/pyddm/model.py
+++ b/pyddm/model.py
@@ -570,9 +570,9 @@ class Model(object):
         pdfsum = np.sum(anal_pdf_corr) + np.sum(anal_pdf_err)
         if pdfsum > 1:
             if pdfsum > 1.01 and param.renorm_warnings:
-                _logger.warning("Renormalizing probability density from " + str(pdfsum) + " to 1. "
-                    " Try decreasing dt.  If that doesn't eliminate this warning, it may be due to"
-                    " extreme parameter values and/or bugs in your model spefication.")
+                _logger.warning(("Renormalizing probability density from " + str(pdfsum) + " to 1."
+                    + "  Try decreasing dt.  If that doesn't eliminate this warning, it may be due"
+                    + " to extreme parameter values and/or bugs in your model spefication."))
                 _logger.debug(self.parameters())
             anal_pdf_corr /= pdfsum
             anal_pdf_err /= pdfsum
@@ -809,13 +809,15 @@ class Model(object):
             sum_negative_strength = np.sum(pdf_corr[pdf_corr<0]) + np.sum(pdf_err[pdf_err<0])
             sum_negative_strength_undec = np.sum(pdf_undec[pdf_undec<0])
             if sum_negative_strength < -.01 and param.renorm_warnings:
-                _logger.warning("Probability density included values less than zero " \
-                    "(minimum=%f, total=%f).  Please decrease dt and/or avoid extreme parameter " \
-                    "values." % (minval, sum_negative_strength))
+                _logger.warning(("Probability density included values less than zero (minimum=%f, "
+                    + "total=%f.  Please decrease dt and/or avoid extreme parameter values.")
+                    % (minval, sum_negative_strength))
+                _logger.debug(self.parameters())
             if sum_negative_strength_undec < -.01 and param.renorm_warnings:
-                _logger.warning("Remaining FP distribution included values less than zero " \
-                    "(minimum=%f, total=%f).  Please decrease dt and/or avoid extreme parameter " \
-                    "values." % (minval, sum_negative_strength_undec))
+                _logger.warning(("Remaining FP distribution included values less than zero "
+                    + "(minimum=%f, total=%f).  Please decrease dt and/or avoid extreme parameter "
+                    + "values.") % (minval, sum_negative_strength_undec))
+                _logger.debug(self.parameters())
             pdf_corr[pdf_corr < 0] = 0
             pdf_err[pdf_err < 0] = 0
             pdf_undec[pdf_undec < 0] = 0
@@ -823,10 +825,10 @@ class Model(object):
         pdfsum = np.sum(pdf_corr) + np.sum(pdf_err) + np.sum(pdf_undec)
         if pdfsum > 1:
             if pdfsum > 1.01 and param.renorm_warnings:
-                _logger.warning("Renormalizing probability density from " + str(pdfsum) + "to 1." \
-                    "  Try decreasing dt or using the implicit (backward Euler) method instead. " \
-                    " If that doesn't eliminate this warning, it may be due to extreme" \
-                    "parameter values and/or bugs in your model spefication.")
+                _logger.warning(("Renormalizing probability density from " + str(pdfsum) + "to 1. "
+                    + " Try decreasing dt or using the implicit (backward Euler) method instead.  "
+                    + "If that doesn't eliminate this warning, it may be due to extreme parameter "
+                    + "values and/or bugs in your model spefication."))
                 _logger.debug(self.parameters())
             pdf_corr /= pdfsum
             pdf_err /= pdfsum
@@ -1040,9 +1042,10 @@ class Model(object):
             sum_negative_strength = np.sum(pdf_corr[pdf_corr<0]) + np.sum(pdf_err[pdf_err<0])
             # For small errors, don't bother alerting the user
             if sum_negative_strength < -.01 and param.renorm_warnings:
-                _logger.warning("Probability density included values less than zero " \
-                    "(minimum=%f, total=%f).  Please decrease dt and/or avoid extreme parameter " \
-                    "values." % (minval, sum_negative_strength))
+                _logger.warning(("Probability density included values less than zero (minimum=%f, "
+                    + "total=%f).  Please decrease dt and/or avoid extreme parameter values.")
+                    % (minval, sum_negative_strength))
+                _logger.debug(self.parameters())
             pdf_corr[pdf_corr < 0] = 0
             pdf_err[pdf_err < 0] = 0
         # Fix numerical errors
@@ -1050,9 +1053,9 @@ class Model(object):
         if pdfsum > 1:
             # If it is only a small renormalization, don't bother alerting the user.
             if pdfsum > 1.01 and param.renorm_warnings:
-                _logger.warning("Renormalizing probability density from " + str(pdfsum) + " to 1. "
-                    " Try decreasing dt.  If that doesn't eliminate this warning, it may be due to"
-                    " extreme parameter values and/or bugs in your model spefication.")
+                _logger.warning(("Renormalizing probability density from " + str(pdfsum) + " to 1."
+                    + "  Try decreasing dt.  If that doesn't eliminate this warning, it may be due"
+                    + " to extreme parameter values and/or bugs in your model spefication."))
                 _logger.debug(self.parameters())
             pdf_corr /= pdfsum
             pdf_err /= pdfsum
@@ -1103,7 +1106,7 @@ class Fittable(float):
         yield Fitted(4, minval=0, maxval=10)
     def __new__(cls, val=np.nan, **kwargs):
         if not np.isnan(val):
-            _logger.error(val)
+            _logger.error("Received positional argument " + str(val))
             raise ValueError("No positional arguments for Fittables")
         return float.__new__(cls, np.nan)
     def __init__(self, **kwargs):

--- a/pyddm/model.py
+++ b/pyddm/model.py
@@ -21,6 +21,7 @@ from .models.paranoid_types import Conditions
 from .sample import Sample
 from .solution import Solution
 from .fitresult import FitResult, FitResultEmpty
+from .logger import logger as _logger
 
 from paranoid.types import Numeric, Number, Self, List, Generic, Positive, Positive0, String, Boolean, Natural1, Natural0, Dict, Set, Integer, NDArray, Maybe, Nothing
 from paranoid.decorators import accepts, returns, requires, ensures, paranoidclass, paranoidconfig
@@ -31,8 +32,6 @@ try:
     HAS_CSOLVE = True
 except ImportError:
     HAS_CSOLVE = False
-
-_logger = logging.getLogger(__package__)
 
 # "Model" describes how a variable is dependent on other variables.
 # Principally, we want to know how drift and noise depend on x and t.
@@ -1106,8 +1105,7 @@ class Fittable(float):
         yield Fitted(4, minval=0, maxval=10)
     def __new__(cls, val=np.nan, **kwargs):
         if not np.isnan(val):
-            _logger.error("Received positional argument " + str(val))
-            raise ValueError("No positional arguments for Fittables")
+            raise ValueError("No positional arguments for Fittables. Received argument: %s." % str(val))
         return float.__new__(cls, np.nan)
     def __init__(self, **kwargs):
         minval = kwargs['minval'] if "minval" in kwargs else -np.inf

--- a/pyddm/model.py
+++ b/pyddm/model.py
@@ -249,7 +249,8 @@ class Model(object):
         """
         old_params = self.get_model_parameters()
         param_object_ids = list(map(id, old_params))
-        assert len(params) == len(param_object_ids), "Invalid params"
+        assert len(params) == len(param_object_ids), "Invalid number of parameters specified: " \
+            "got %i, expected %i" % (len(params), len(param_object_ids))
         new_params = [p if isinstance(p, Fittable) else op.make_fitted(p) \
                       for p,op in zip(params, old_params)]
         for dep in self.dependencies:

--- a/pyddm/model.py
+++ b/pyddm/model.py
@@ -4,6 +4,7 @@
 # This file is part of PyDDM, and is available under the MIT license.
 # Please see LICENSE.txt in the root directory for more information.
 
+import logging
 import numpy as np
 from scipy import sparse
 import scipy.sparse.linalg
@@ -135,9 +136,9 @@ class Model(object):
         self.dx = dx
         self.dt = dt
         if self.dx > .01:
-            print("WARNING: dx is large.  Estimated pdfs may be imprecise.  Decrease dx to 0.01 or less.")
+            logging.warning("dx is large.  Estimated pdfs may be imprecise.  Decrease dx to 0.01 or less.")
         if self.dt > .01:
-            print("WARNING: dt is large.  Estimated pdfs may be imprecise.  Decrease dt to 0.01 or less.")
+            logging.warning("dt is large.  Estimated pdfs may be imprecise.  Decrease dt to 0.01 or less.")
         self.T_dur = T_dur
         self.fitresult = FitResultEmpty() if fitresult is None else fitresult # If the model was fit, store the status here
     # Get a string representation of the model
@@ -425,7 +426,7 @@ class Model(object):
 
         for s in range(0, size):
             if s % 200 == 0:
-                print("Simulating trial %i" % s)
+                logging.info("Simulating trial %i" % s)
             timecourse = self.simulate_trial(conditions=conditions, seed=(hash((s, seed)) % 2**32), cutoff=True, rk4=rk4)
             T_finish = T[len(timecourse) - 1]
             B = self.get_dependence("bound").get_bound(t=T_finish, conditions=conditions)
@@ -568,9 +569,9 @@ class Model(object):
         pdfsum = np.sum(anal_pdf_corr) + np.sum(anal_pdf_err)
         if pdfsum > 1:
             if pdfsum > 1.01 and param.renorm_warnings:
-                print("Warning: renormalizing probability density from", pdfsum, "to 1.  " \
-                      "Try decreasing dt.  If that doesn't eliminate this warning, it may be due to " \
-                      "extreme parameter values and/or bugs in your model speficiation.")
+                logging.warning("Renormalizing probability density from " + str(pdfsum) + " to 1. "
+                    " Try decreasing dt.  If that doesn't eliminate this warning, it may be due to"
+                    " extreme parameter values and/or bugs in your model speficiation.")
             anal_pdf_corr /= pdfsum
             anal_pdf_err /= pdfsum
 
@@ -684,7 +685,7 @@ class Model(object):
             if return_evolution == False:
                 return self.solve_numerical_cn(conditions=conditions)
             else:
-                print("Warning: return_evolution is not supported with the Crank-Nicolson solver, using implicit (backward Euler) instead.")
+                logging.warning("return_evolution is not supported with the Crank-Nicolson solver, using implicit (backward Euler) instead.")
                 method = "implicit"
 
         # Initial condition of decision variable
@@ -806,13 +807,13 @@ class Model(object):
             sum_negative_strength = np.sum(pdf_corr[pdf_corr<0]) + np.sum(pdf_err[pdf_err<0])
             sum_negative_strength_undec = np.sum(pdf_undec[pdf_undec<0])
             if sum_negative_strength < -.01 and param.renorm_warnings:
-                print("Warning: probability density included values less than zero "
-                      "(minimum=%f, total=%f).  "  \
-                      "Please decrease dt and/or avoid extreme parameter values." % (minval, sum_negative_strength))
+                logging.warning("Probability density included values less than zero " \
+                    "(minimum=%f, total=%f).  Please decrease dt and/or avoid extreme parameter " \
+                    "values." % (minval, sum_negative_strength))
             if sum_negative_strength_undec < -.01 and param.renorm_warnings:
-                print("Warning: remaining FP distribution included values less than zero " \
-                      "(minimum=%f, total=%f).  " \
-                      "Please decrease dt and/or avoid extreme parameter values." % (minval, sum_negative_strength_undec))
+                logging.warning("Remaining FP distribution included values less than zero " \
+                    "(minimum=%f, total=%f).  Please decrease dt and/or avoid extreme parameter " \
+                    "values." % (minval, sum_negative_strength_undec))
             pdf_corr[pdf_corr < 0] = 0
             pdf_err[pdf_err < 0] = 0
             pdf_undec[pdf_undec < 0] = 0
@@ -820,10 +821,10 @@ class Model(object):
         pdfsum = np.sum(pdf_corr) + np.sum(pdf_err) + np.sum(pdf_undec)
         if pdfsum > 1:
             if pdfsum > 1.01 and param.renorm_warnings:
-                print("Warning: renormalizing probability density from", pdfsum, "to 1.  " \
-                      "Try decreasing dt or using the implicit (backward Euler) method instead.  " \
-                      "If that doesn't eliminate this warning, it may be due to " \
-                      "extreme parameter values and/or bugs in your model speficiation.")
+                logging.warning("Renormalizing probability density from " + str(pdfsum) + "to 1." \
+                    "  Try decreasing dt or using the implicit (backward Euler) method instead. " \
+                    " If that doesn't eliminate this warning, it may be due to extreme" \
+                    "parameter values and/or bugs in your model speficiation.")
             pdf_corr /= pdfsum
             pdf_err /= pdfsum
             pdf_undec /= pdfsum
@@ -1036,9 +1037,9 @@ class Model(object):
             sum_negative_strength = np.sum(pdf_corr[pdf_corr<0]) + np.sum(pdf_err[pdf_err<0])
             # For small errors, don't bother alerting the user
             if sum_negative_strength < -.01 and param.renorm_warnings:
-                print("Warning: probability density included values less than zero "
-                      "(minimum=%f, total=%f).  " \
-                      "Please decrease dt and/or avoid extreme parameter values." % (minval, sum_negative_strength))
+                logging.warning("Probability density included values less than zero " \
+                    "(minimum=%f, total=%f).  Please decrease dt and/or avoid extreme parameter " \
+                    "values." % (minval, sum_negative_strength))
             pdf_corr[pdf_corr < 0] = 0
             pdf_err[pdf_err < 0] = 0
         # Fix numerical errors
@@ -1046,9 +1047,9 @@ class Model(object):
         if pdfsum > 1:
             # If it is only a small renormalization, don't bother alerting the user.
             if pdfsum > 1.01 and param.renorm_warnings:
-                print("Warning: renormalizing probability density from", pdfsum, "to 1.  " \
-                      "Try decreasing dt.  If that doesn't eliminate this warning, it may be due to " \
-                      "extreme parameter values and/or bugs in your model speficiation.")
+                logging.warning("Renormalizing probability density from", pdfsum, "to 1.  Try " \
+                    "decreasing dt.  If that doesn't eliminate this warning, it may be due to " \
+                    "extreme parameter values and/or bugs in your model speficiation.")
             pdf_corr /= pdfsum
             pdf_err /= pdfsum
 
@@ -1098,7 +1099,7 @@ class Fittable(float):
         yield Fitted(4, minval=0, maxval=10)
     def __new__(cls, val=np.nan, **kwargs):
         if not np.isnan(val):
-            print(val)
+            logging.error(val)
             raise ValueError("No positional arguments for Fittables")
         return float.__new__(cls, np.nan)
     def __init__(self, **kwargs):

--- a/pyddm/models/loss.py
+++ b/pyddm/models/loss.py
@@ -6,6 +6,7 @@
 
 __all__ = ['LossFunction', 'LossSquaredError', 'LossLikelihood', 'LossBIC', 'LossRobustLikelihood', 'LossRobustBIC']
 
+import logging
 import numpy as np
 
 from paranoid.decorators import accepts, returns, requires, ensures, paranoidclass
@@ -181,9 +182,9 @@ class LossLikelihood(LossFunction):
                 except FloatingPointError:
                     minlike = min(np.min(sols[k].pdf_corr()), np.min(sols[k].pdf_corr()))
                     if minlike == 0:
-                        print("Warning: infinite likelihood encountered. Please either use a Robust likelihood method (e.g. LossRobustLikelihood or LossRobustBIC) or even better use a mixture model (via an Overlay) which covers the full range of simulated times to avoid infinite negative log likelihood.  See the FAQs in the documentation for more information.")
+                        logging.warning("Infinite likelihood encountered. Please either use a Robust likelihood method (e.g. LossRobustLikelihood or LossRobustBIC) or even better use a mixture model (via an Overlay) which covers the full range of simulated times to avoid infinite negative log likelihood.  See the FAQs in the documentation for more information.")
                     elif minlike < 0:
-                        print("Warning: infinite likelihood encountered. Simulated histogram is less than zero in likelihood calculation.  Try decreasing dt.")
+                        logging.warning("Infinite likelihood encountered. Simulated histogram is less than zero in likelihood calculation.  Try decreasing dt.")
                     return np.inf
             # This is not a valid way to incorporate undecided trials into a likelihood
             #if sols[k].prob_undecided() > 0:

--- a/pyddm/models/loss.py
+++ b/pyddm/models/loss.py
@@ -14,6 +14,8 @@ from paranoid.types import Self, Number, Positive0, Natural1
 from ..sample import Sample
 from ..model import Model
 
+_logger = logging.getLogger(__package__)
+
 class LossFunction(object):
     """An abstract class for a function to assess goodness of fit.
 
@@ -182,9 +184,11 @@ class LossLikelihood(LossFunction):
                 except FloatingPointError:
                     minlike = min(np.min(sols[k].pdf_corr()), np.min(sols[k].pdf_corr()))
                     if minlike == 0:
-                        logging.warning("Infinite likelihood encountered. Please either use a Robust likelihood method (e.g. LossRobustLikelihood or LossRobustBIC) or even better use a mixture model (via an Overlay) which covers the full range of simulated times to avoid infinite negative log likelihood.  See the FAQs in the documentation for more information.")
+                        _logger.warning("Infinite likelihood encountered. Please either use a Robust likelihood method (e.g. LossRobustLikelihood or LossRobustBIC) or even better use a mixture model (via an Overlay) which covers the full range of simulated times to avoid infinite negative log likelihood.  See the FAQs in the documentation for more information.")
+                        _logger.debug(model.parameters())
                     elif minlike < 0:
-                        logging.warning("Infinite likelihood encountered. Simulated histogram is less than zero in likelihood calculation.  Try decreasing dt.")
+                        _logger.warning("Infinite likelihood encountered. Simulated histogram is less than zero in likelihood calculation.  Try decreasing dt.")
+                        _logger.debug(model.parameters())
                     return np.inf
             # This is not a valid way to incorporate undecided trials into a likelihood
             #if sols[k].prob_undecided() > 0:

--- a/pyddm/models/loss.py
+++ b/pyddm/models/loss.py
@@ -13,8 +13,7 @@ from paranoid.decorators import accepts, returns, requires, ensures, paranoidcla
 from paranoid.types import Self, Number, Positive0, Natural1
 from ..sample import Sample
 from ..model import Model
-
-_logger = logging.getLogger(__package__)
+from ..logger import logger as _logger
 
 class LossFunction(object):
     """An abstract class for a function to assess goodness of fit.

--- a/pyddm/models/loss.py
+++ b/pyddm/models/loss.py
@@ -185,10 +185,9 @@ class LossLikelihood(LossFunction):
                     minlike = min(np.min(sols[k].pdf_corr()), np.min(sols[k].pdf_corr()))
                     if minlike == 0:
                         _logger.warning("Infinite likelihood encountered. Please either use a Robust likelihood method (e.g. LossRobustLikelihood or LossRobustBIC) or even better use a mixture model (via an Overlay) which covers the full range of simulated times to avoid infinite negative log likelihood.  See the FAQs in the documentation for more information.")
-                        _logger.debug(model.parameters())
                     elif minlike < 0:
                         _logger.warning("Infinite likelihood encountered. Simulated histogram is less than zero in likelihood calculation.  Try decreasing dt.")
-                        _logger.debug(model.parameters())
+                    _logger.debug(model.parameters())
                     return np.inf
             # This is not a valid way to incorporate undecided trials into a likelihood
             #if sols[k].prob_undecided() > 0:

--- a/pyddm/models/loss.py
+++ b/pyddm/models/loss.py
@@ -152,7 +152,7 @@ class LossLikelihood(LossFunction):
         for comb in self.sample.condition_combinations(required_conditions=self.required_conditions):
             s = self.sample.subset(**comb)
             maxt = max(max(s.corr) if s.corr.size != 0 else -1, max(s.err) if s.err.size != 0 else -1)
-            assert maxt <= self.T_dur, "Simulation time T_dur=%f not long enough for these data" % self.T_dur
+            assert maxt <= self.T_dur, "Simulation time T_dur=%f not long enough for these data. (max sample RT=%f)" % (self.T_dur, maxt)
             # Find the integers which correspond to the timepoints in
             # the pdfs.  Also don't group them into the first bin
             # because this creates bias.

--- a/pyddm/plot.py
+++ b/pyddm/plot.py
@@ -11,10 +11,12 @@ import traceback
 import time
 from paranoid.settings import Settings as paranoid_settings
 
+_logger = logging.getLogger(__package__)
+
 # A workaround for a bug on Mac related to FigureCanvasTKAgg
 if 'matplotlib.pyplot' in sys.modules and sys.platform == 'darwin':
     _gui_compatible = False
-    logging.warning("model_gui function unavailable.  To use model_gui, please import ddm.plot " \
+    _logger.warning("model_gui function unavailable.  To use model_gui, please import ddm.plot " \
         "before matplotlib.pyplot.")
 else:
     _gui_compatible = True
@@ -120,7 +122,7 @@ def plot_decision_variable_distribution(model, conditions={}, resolution=.1, fig
     # resolution) so this should be improved someday...
     s = model.solve_numerical_implicit(conditions=conditions, return_evolution=True)
     hists = s.pdf_evolution()
-    logging.info(np.max(hists))
+    _logger.info(np.max(hists))
     top = s.pdf_corr()
     bot = s.pdf_err()
     # Plot the output
@@ -304,7 +306,7 @@ def model_gui(model,
         required_conditions = sample.condition_names()
         sample_condition_values = {cond: sample.condition_values(cond) for cond in required_conditions}
     else:
-        logging.error("Must define model, sample, or both")
+        _logger.error("Must define model, sample, or both")
         return
     
     params = [] # A list of all of the Fittables that were passed.
@@ -547,7 +549,7 @@ def model_gui_jupyter(model,
         required_conditions = sample.condition_names()
         sample_condition_values = {cond: sample.condition_values(cond) for cond in required_conditions}
     else:
-        logging.error("Must define model, sample, or both")
+        _logger.error("Must define model, sample, or both")
         return
     # Set up params
     params = model.get_model_parameters()
@@ -562,7 +564,7 @@ def model_gui_jupyter(model,
         # with a "_c_".  Here we detect what is what, and strip away
         # the prefix.
         if not util_widgets[0].value and not util_widgets[2].value:
-            logging.info("Update to see new plot")
+            _logger.info("Update to see new plot")
             return
         for k,v in kwargs.items():
             if k.startswith("_c_"):

--- a/pyddm/plot.py
+++ b/pyddm/plot.py
@@ -564,7 +564,7 @@ def model_gui_jupyter(model,
         # with a "_c_".  Here we detect what is what, and strip away
         # the prefix.
         if not util_widgets[0].value and not util_widgets[2].value:
-            _logger.info("Update to see new plot")
+            _logger.info("Update to see new plot")  # TODO info or warning?
             return
         for k,v in kwargs.items():
             if k.startswith("_c_"):

--- a/pyddm/plot.py
+++ b/pyddm/plot.py
@@ -10,8 +10,7 @@ import sys
 import traceback
 import time
 from paranoid.settings import Settings as paranoid_settings
-
-_logger = logging.getLogger(__package__)
+from .logger import logger as _logger
 
 # A workaround for a bug on Mac related to FigureCanvasTKAgg
 if 'matplotlib.pyplot' in sys.modules and sys.platform == 'darwin':
@@ -122,7 +121,6 @@ def plot_decision_variable_distribution(model, conditions={}, resolution=.1, fig
     # resolution) so this should be improved someday...
     s = model.solve_numerical_implicit(conditions=conditions, return_evolution=True)
     hists = s.pdf_evolution()
-    _logger.info(np.max(hists))
     top = s.pdf_corr()
     bot = s.pdf_err()
     # Plot the output
@@ -564,7 +562,7 @@ def model_gui_jupyter(model,
         # with a "_c_".  Here we detect what is what, and strip away
         # the prefix.
         if not util_widgets[0].value and not util_widgets[2].value:
-            _logger.info("Update to see new plot")  # TODO info or warning?
+            print("Update to see new plot")
             return
         for k,v in kwargs.items():
             if k.startswith("_c_"):

--- a/pyddm/plot.py
+++ b/pyddm/plot.py
@@ -4,6 +4,7 @@
 # This file is part of PyDDM, and is available under the MIT license.
 # Please see LICENSE.txt in the root directory for more information.
 
+import logging
 import numpy as np
 import sys
 import traceback
@@ -13,8 +14,8 @@ from paranoid.settings import Settings as paranoid_settings
 # A workaround for a bug on Mac related to FigureCanvasTKAgg
 if 'matplotlib.pyplot' in sys.modules and sys.platform == 'darwin':
     _gui_compatible = False
-    print("Warning: model_gui funciton unavailable.  To use model_gui, please" \
-          " import ddm.plot before matplotlib.pyplot.")
+    logging.warning("model_gui function unavailable.  To use model_gui, please import ddm.plot " \
+        "before matplotlib.pyplot.")
 else:
     _gui_compatible = True
     if sys.platform == 'darwin':
@@ -119,7 +120,7 @@ def plot_decision_variable_distribution(model, conditions={}, resolution=.1, fig
     # resolution) so this should be improved someday...
     s = model.solve_numerical_implicit(conditions=conditions, return_evolution=True)
     hists = s.pdf_evolution()
-    print(np.max(hists))
+    logging.info(np.max(hists))
     top = s.pdf_corr()
     bot = s.pdf_err()
     # Plot the output
@@ -303,7 +304,7 @@ def model_gui(model,
         required_conditions = sample.condition_names()
         sample_condition_values = {cond: sample.condition_values(cond) for cond in required_conditions}
     else:
-        print("Must define model, sample, or both")
+        logging.error("Must define model, sample, or both")
         return
     
     params = [] # A list of all of the Fittables that were passed.
@@ -546,7 +547,7 @@ def model_gui_jupyter(model,
         required_conditions = sample.condition_names()
         sample_condition_values = {cond: sample.condition_values(cond) for cond in required_conditions}
     else:
-        print("Must define model, sample, or both")
+        logging.error("Must define model, sample, or both")
         return
     # Set up params
     params = model.get_model_parameters()
@@ -561,7 +562,7 @@ def model_gui_jupyter(model,
         # with a "_c_".  Here we detect what is what, and strip away
         # the prefix.
         if not util_widgets[0].value and not util_widgets[2].value:
-            print("Update to see new plot")
+            logging.info("Update to see new plot")
             return
         for k,v in kwargs.items():
             if k.startswith("_c_"):

--- a/pyddm/sample.py
+++ b/pyddm/sample.py
@@ -4,6 +4,7 @@
 # This file is part of PyDDM, and is available under the MIT license.
 # Please see LICENSE.txt in the root directory for more information.
 
+import logging
 import numpy as np
 import itertools
 
@@ -207,9 +208,9 @@ class Sample(object):
         not yet work with undecided trials.
         """
         if len(df) == 0:
-            print("Warning: Empty DataFrame")
+            logging.warning("Empty DataFrame")
         if np.mean(df[rt_column_name]) > 50:
-            print("Warning: RTs should be specified in seconds, not milliseconds")
+            logging.warning("RTs should be specified in seconds, not milliseconds")
         for _,col in df.items():
             if len(df) > 0 and isinstance(col.iloc[0], (list, np.ndarray)):
                 raise ValueError("Conditions should not be lists or ndarrays.  Please convert to a tuple instead.")

--- a/pyddm/sample.py
+++ b/pyddm/sample.py
@@ -11,8 +11,7 @@ import itertools
 from paranoid.types import NDArray, Number, List, String, Self, Positive, Positive0, Range, Natural0, Unchecked, Dict, Maybe, Nothing, Boolean
 from paranoid.decorators import *
 from .models.paranoid_types import Conditions
-
-_logger = logging.getLogger(__package__)
+from .logger import logger as _logger
 
 @paranoidclass
 class Sample(object):

--- a/pyddm/sample.py
+++ b/pyddm/sample.py
@@ -12,6 +12,8 @@ from paranoid.types import NDArray, Number, List, String, Self, Positive, Positi
 from paranoid.decorators import *
 from .models.paranoid_types import Conditions
 
+_logger = logging.getLogger(__package__)
+
 @paranoidclass
 class Sample(object):
     """Describes a sample from some (empirical or simulated) distribution.
@@ -208,9 +210,9 @@ class Sample(object):
         not yet work with undecided trials.
         """
         if len(df) == 0:
-            logging.warning("Empty DataFrame")
+            _logger.warning("Empty DataFrame")
         if np.mean(df[rt_column_name]) > 50:
-            logging.warning("RTs should be specified in seconds, not milliseconds")
+            _logger.warning("RTs should be specified in seconds, not milliseconds")
         for _,col in df.items():
             if len(df) > 0 and isinstance(col.iloc[0], (list, np.ndarray)):
                 raise ValueError("Conditions should not be lists or ndarrays.  Please convert to a tuple instead.")

--- a/pyddm/solution.py
+++ b/pyddm/solution.py
@@ -154,9 +154,9 @@ class Solution(object):
         # Common mistake so we want to warn the user of any possible
         # misunderstanding.
         if not isinstance(self.model.get_dependence("overlay"), OverlayNone):
-            _logger.warning("Undecided probability accessed for model with overlays.  "
-                "Undecided probability applies *before* overlays.  Please see the "
-                "pdf_undec docs for more information and to prevent misunderstanding.")
+            _logger.warning(("Undecided probability accessed for model with overlays.  Undecided "
+                + "probability applies *before* overlays.  Please see the pdf_undec docs for more "
+                + "information and to prevent misunderstanding."))
         if self.undec is not None:
             return self.undec/self.model.dx
         else:
@@ -196,9 +196,9 @@ class Solution(object):
         # Common mistake so we want to warn the user of any possible
         # misunderstanding.
         if not isinstance(self.model.get_dependence("overlay"), OverlayNone):
-            _logger.warning("Probability evolution accessed for model with overlays.  "
-                            "Probability evolution applies *before* overlays.  Please see the "
-                            "evolution docs for more information and to prevent misunderstanding.")
+            _logger.warning(("Probability evolution accessed for model with overlays.  Probability"
+                + "evolution applies *before* overlays.  Please see the evolution docs for more "
+                + "information and to prevent misunderstanding."))
         if self.evolution is not None:
             return self.evolution/self.model.dx
         else:

--- a/pyddm/solution.py
+++ b/pyddm/solution.py
@@ -5,6 +5,7 @@
 # Please see LICENSE.txt in the root directory for more information.
 
 import copy
+import logging
 import numpy as np
 from paranoid.types import NDArray, Generic, Number, Self, Positive0, Range, Natural1, Natural0, Maybe
 from paranoid.decorators import accepts, returns, requires, ensures, paranoidclass
@@ -151,9 +152,9 @@ class Solution(object):
         # Common mistake so we want to warn the user of any possible
         # misunderstanding.
         if not isinstance(self.model.get_dependence("overlay"), OverlayNone):
-            print("WARNING: Undecided probability accessed for model with overlays.  "
-                  "Undecided probability applies *before* overlays.  Please see the "
-                  "pdf_undec docs for more information and to prevent misunderstanding.")
+            logging.warning("Undecided probability accessed for model with overlays.  "
+                "Undecided probability applies *before* overlays.  Please see the "
+                "pdf_undec docs for more information and to prevent misunderstanding.")
         if self.undec is not None:
             return self.undec/self.model.dx
         else:
@@ -193,9 +194,9 @@ class Solution(object):
         # Common mistake so we want to warn the user of any possible
         # misunderstanding.
         if not isinstance(self.model.get_dependence("overlay"), OverlayNone):
-            print("WARNING: Probability evolution accessed for model with overlays.  "
-                  "Probability evolution applies *before* overlays.  Please see the "
-                  "evolution docs for more information and to prevent misunderstanding.")
+            logging.warning("Probability evolution accessed for model with overlays.  "
+                            "Probability evolution applies *before* overlays.  Please see the "
+                            "evolution docs for more information and to prevent misunderstanding.")
         if self.evolution is not None:
             return self.evolution/self.model.dx
         else:
@@ -232,7 +233,7 @@ class Solution(object):
         """The probability of not responding during the time limit."""
         udprob = 1 - np.sum(self.corr) - np.sum(self.err)
         if udprob < 0:
-            print("Warning, setting undecided probability from %f to 0" % udprob)
+            logging.warning("Setting undecided probability from %f to 0" % udprob)
             udprob = 0
         return udprob
 
@@ -325,7 +326,7 @@ class Solution(object):
         combined_domain = list(shorter_t_domain) + list(shorter_t_domain+shift) + [-1]
         combined_probs = list(shorter_pdf_corr*self.model.dt) + list(shorter_pdf_err*self.model.dt) + [self.prob_undecided()]
         if np.abs(np.sum(combined_probs)-1) >= .0001:
-            print("Warning, distribution sums to %f rather than 1" % np.sum(combined_probs))
+            logging.warning("Distribution sums to %f rather than 1" % np.sum(combined_probs))
         samp = rng.choice(combined_domain, p=combined_probs, replace=True, size=k)
         undecided = np.sum(samp==-1)
         samp = samp[samp != -1] # Remove undecided trials

--- a/pyddm/solution.py
+++ b/pyddm/solution.py
@@ -235,6 +235,7 @@ class Solution(object):
         udprob = 1 - np.sum(self.corr) - np.sum(self.err)
         if udprob < 0:
             _logger.warning("Setting undecided probability from %f to 0" % udprob)
+            _logger.debug(self.model.parameters())
             udprob = 0
         return udprob
 

--- a/pyddm/solution.py
+++ b/pyddm/solution.py
@@ -12,6 +12,8 @@ from paranoid.decorators import accepts, returns, requires, ensures, paranoidcla
 from .models.paranoid_types import Conditions
 from .sample import Sample
 
+_logger = logging.getLogger(__package__)
+
 @paranoidclass
 class Solution(object):
     """Describes the result of an analytic or numerical DDM run.
@@ -152,7 +154,7 @@ class Solution(object):
         # Common mistake so we want to warn the user of any possible
         # misunderstanding.
         if not isinstance(self.model.get_dependence("overlay"), OverlayNone):
-            logging.warning("Undecided probability accessed for model with overlays.  "
+            _logger.warning("Undecided probability accessed for model with overlays.  "
                 "Undecided probability applies *before* overlays.  Please see the "
                 "pdf_undec docs for more information and to prevent misunderstanding.")
         if self.undec is not None:
@@ -194,7 +196,7 @@ class Solution(object):
         # Common mistake so we want to warn the user of any possible
         # misunderstanding.
         if not isinstance(self.model.get_dependence("overlay"), OverlayNone):
-            logging.warning("Probability evolution accessed for model with overlays.  "
+            _logger.warning("Probability evolution accessed for model with overlays.  "
                             "Probability evolution applies *before* overlays.  Please see the "
                             "evolution docs for more information and to prevent misunderstanding.")
         if self.evolution is not None:
@@ -233,7 +235,7 @@ class Solution(object):
         """The probability of not responding during the time limit."""
         udprob = 1 - np.sum(self.corr) - np.sum(self.err)
         if udprob < 0:
-            logging.warning("Setting undecided probability from %f to 0" % udprob)
+            _logger.warning("Setting undecided probability from %f to 0" % udprob)
             udprob = 0
         return udprob
 
@@ -326,7 +328,7 @@ class Solution(object):
         combined_domain = list(shorter_t_domain) + list(shorter_t_domain+shift) + [-1]
         combined_probs = list(shorter_pdf_corr*self.model.dt) + list(shorter_pdf_err*self.model.dt) + [self.prob_undecided()]
         if np.abs(np.sum(combined_probs)-1) >= .0001:
-            logging.warning("Distribution sums to %f rather than 1" % np.sum(combined_probs))
+            _logger.warning("Distribution sums to %f rather than 1" % np.sum(combined_probs))
         samp = rng.choice(combined_domain, p=combined_probs, replace=True, size=k)
         undecided = np.sum(samp==-1)
         samp = samp[samp != -1] # Remove undecided trials

--- a/pyddm/solution.py
+++ b/pyddm/solution.py
@@ -11,8 +11,7 @@ from paranoid.types import NDArray, Generic, Number, Self, Positive0, Range, Nat
 from paranoid.decorators import accepts, returns, requires, ensures, paranoidclass
 from .models.paranoid_types import Conditions
 from .sample import Sample
-
-_logger = logging.getLogger(__package__)
+from .logger import logger as _logger
 
 @paranoidclass
 class Solution(object):

--- a/pyddm/solution.py
+++ b/pyddm/solution.py
@@ -329,6 +329,7 @@ class Solution(object):
         combined_probs = list(shorter_pdf_corr*self.model.dt) + list(shorter_pdf_err*self.model.dt) + [self.prob_undecided()]
         if np.abs(np.sum(combined_probs)-1) >= .0001:
             _logger.warning("Distribution sums to %f rather than 1" % np.sum(combined_probs))
+            _logger.debug(self.model.parameters())
         samp = rng.choice(combined_domain, p=combined_probs, replace=True, size=k)
         undecided = np.sum(samp==-1)
         samp = samp[samp != -1] # Remove undecided trials

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,6 +1,8 @@
 #!/bin/bash -e
 PYTHON=python3
 
+# Ensure that the C extension is built before testing: python setup.py build_ext --inplace
+
 $PYTHON -m paranoid paranoid_tests.py
 $PYTHON -m pytest unit_tests.py
 $PYTHON -m pytest integration_tests.py


### PR DESCRIPTION
I've tried to replace all logging-related `print` statements with the calls to a `Logger` object from the `logging` library. The immediate benefit is that we can have more granular control of logging: in the current implementation, the `set_debug_flag()` function allows the user to hide messages at the `logging.DEBUG` level (default) or to show them. This could easily be adapted to level-by-level control (e.g. hide `logging.INFO` but show warnings and errors) if desired. It could also be extended e.g. for logging to a file.

I've also tried to interpret the existing print statements into the appropriate "info" and "warning" categories, but it's certainly possible that I may have misinterpreted somewhere along the way. See the comments with "TODO" for a few uncertain cases.

At the moment, the only debug-level messages are those that I have added. Following certain warning statements, they print out the current model parameters. This has been helpful for me but may or may not be what the library needs!

Lastly, the current log format looks like `filename.py:fileno Loglevel: <message>`. Again this could be easily changed if desired. Here is a small example demonstrating the format and the debug flag:

```python
import pandas as pd
import pyddm

m = pyddm.Model(bound=pyddm.BoundConstant(B=100))

data = pyddm.Sample.from_pandas_dataframe(pd.DataFrame([{'RT': 1, 'correct': 0}]), rt_column_name='RT', correct_column_name='correct')
pyddm.get_model_loss(m, data, lossfunction=pyddm.LossLikelihood)
```
Outputs:
```
loss.py:187 Warning: Infinite likelihood encountered. Please either use a Robust likelihood method (e.g. LossRobustLikelihood or LossRobustBIC) or even better use a mixture model (via an Overlay) which covers the full range of simulated times to avoid infinite negative log likelihood.  See the FAQs in the documentation for more information.
```
But,
```python
pyddm.set_debug_flag(True)
pyddm.get_model_loss(m, data, lossfunction=pyddm.LossLikelihood)
```
Outputs:
```
loss.py:187 Warning: Infinite likelihood encountered. Please either use a Robust likelihood method (e.g. LossRobustLikelihood or LossRobustBIC) or even better use a mixture model (via an Overlay) which covers the full range of simulated times to avoid infinite negative log likelihood.  See the FAQs in the documentation for more information.
loss.py:190 Debug: {'drift': {'drift': 0}, 'noise': {'noise': 1}, 'bound': {'B': 100}, 'IC': {}, 'overlay': {}}
```

P.S. all tests passing.